### PR TITLE
Add Redeem event

### DIFF
--- a/evm/src/circle_integration/CircleIntegration.sol
+++ b/evm/src/circle_integration/CircleIntegration.sol
@@ -21,6 +21,14 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
     using BytesLib for bytes;
 
     /**
+     * @notice Emitted when Circle-support assets have been minted to the mintRecipient
+     * @param emitterChainId Wormhole chain ID of emitter contract on source chain
+     * @param emitterAddress Address (bytes32 zero-left-padded) of emitter on source chain
+     * @param sequence Sequence of Wormhole message used to mint tokens
+     */
+    event Redeemed(uint16 indexed emitterChainId, bytes32 indexed emitterAddress, uint64 indexed sequence);
+
+    /**
      * @notice `transferTokensWithPayload` calls the Circle Bridge contract to burn Circle-supported tokens. It emits
      * a Wormhole message containing a user-specified payload with instructions for what to do with
      * the Circle-supported assets once they have been minted on the target chain.
@@ -175,6 +183,9 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
         // call the circle bridge to mint tokens to the recipient
         bool success = circleTransmitter().receiveMessage(params.circleBridgeMessage, params.circleAttestation);
         require(success, "CIRCLE_INTEGRATION: failed to mint tokens");
+
+        // emit Redeemed event
+        emit Redeemed(verifiedMessage.emitterChainId, verifiedMessage.emitterAddress, verifiedMessage.sequence);
     }
 
     function verifyWormholeRedeemMessage(bytes memory encodedMessage) internal returns (IWormhole.VM memory) {

--- a/evm/src/circle_integration/CircleIntegrationGovernance.sol
+++ b/evm/src/circle_integration/CircleIntegrationGovernance.sol
@@ -211,7 +211,7 @@ contract CircleIntegrationGovernance is CircleIntegrationGetters, ERC1967Upgrade
 
     function verifyAndConsumeGovernanceMessage(bytes memory encodedMessage, uint8 action)
         internal
-        returns (bytes memory payload)
+        returns (bytes memory)
     {
         // verify the governance message
         (bytes32 messageHash, bytes memory payload) = verifyGovernanceMessage(encodedMessage, action);

--- a/evm/ts/test/helpers/utils.ts
+++ b/evm/ts/test/helpers/utils.ts
@@ -60,6 +60,24 @@ export function findWormholeMessageInLogs(
   return null;
 }
 
+export function findRedeemEventInLogs(
+  logs: ethers.providers.Log[],
+  circleIntegrationAddress: string
+): ethers.utils.Result {
+  let result: ethers.utils.Result = {} as ethers.utils.Result;
+  for (const log of logs) {
+    if (log.address == circleIntegrationAddress) {
+      const iface = new ethers.utils.Interface([
+        "event Redeemed(uint16 indexed emitterChainId, bytes32 indexed emitterAddress, uint64 indexed sequence)",
+      ]);
+
+      result = iface.parseLog(log).args;
+      break;
+    }
+  }
+  return result;
+}
+
 export class MockCircleAttester {
   privateKey: string;
 


### PR DESCRIPTION
The purpose of this PR is to add an event that can be used by UIs to notify users when their Circle-supported assets have been minted on the target chain. 