### PR TITLE
evm: update state variable documentation and add gas optimization

### DIFF
--- a/evm/src/circle_integration/CircleIntegration.sol
+++ b/evm/src/circle_integration/CircleIntegration.sol
@@ -155,7 +155,7 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
      * - `mintRecipient` Recipient of minted tokens (must be caller of this contract)
      * - `payload` Arbitrary Wormhole message payload
      */
-    function redeemTokensWithPayload(RedeemParameters memory params)
+    function redeemTokensWithPayload(RedeemParameters calldata params)
         public
         returns (DepositWithPayload memory depositInfo)
     {
@@ -211,7 +211,10 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
 
     function verifyEmitter(IWormhole.VM memory vm) internal view returns (bool) {
         // verify that the sender of the wormhole message is a trusted
-        return (getRegisteredEmitter(vm.emitterChainId) == vm.emitterAddress);
+        return (
+            getRegisteredEmitter(vm.emitterChainId) == vm.emitterAddress &&
+            vm.emitterAddress != bytes32(0)
+        );
     }
 
     function verifyCircleMessage(bytes memory circleMessage, uint32 sourceDomain, uint32 targetDomain, uint64 nonce)

--- a/evm/src/circle_integration/CircleIntegrationState.sol
+++ b/evm/src/circle_integration/CircleIntegrationState.sol
@@ -3,55 +3,55 @@ pragma solidity ^0.8.19;
 
 contract CircleIntegrationStorage {
     struct State {
-        /// @dev Wormhole chain ID of this contract
+        /// Wormhole chain ID of this contract
         uint16 chainId;
 
         /**
-         * @dev The number of block confirmations needed before the wormhole network
+         * The number of block confirmations needed before the wormhole network
          * will attest a message.
          */
         uint8 wormholeFinality;
 
-        /// @dev Circle domain for this blockchain (grabbed from Circle's MessageTransmitter)
+        /// Circle domain for this blockchain (grabbed from Circle's MessageTransmitter)
         uint32 localDomain;
 
-        /// @dev address of the Wormhole contract on this chain
+        /// address of the Wormhole contract on this chain
         address wormhole;
 
-        /// @dev Wormhole governance chain ID
+        /// Wormhole governance chain ID
         uint16 governanceChainId;
 
-        /// @dev Wormhole governance contract address (bytes32 zero-left-padded)
+        /// Wormhole governance contract address (bytes32 zero-left-padded)
         bytes32 governanceContract;
 
-        /// @dev address of the Circle Bridge contract on this chain
+        /// address of the Circle Bridge contract on this chain
         address circleBridgeAddress;
 
-        /// @dev address of the Circle Message Transmitter on this chain
+        /// address of the Circle Message Transmitter on this chain
         address circleTransmitterAddress;
 
-        /// @dev address of the Circle Token Minter on this chain
+        /// address of the Circle Token Minter on this chain
         address circleTokenMinterAddress;
 
-        /// @dev mapping of initialized implementation (logic) contracts
+        /// mapping of initialized implementation (logic) contracts
         mapping(address => bool) initializedImplementations;
 
-        /// @dev Wormhole chain ID to known emitter address mapping
+        /// Wormhole chain ID to known emitter address mapping
         mapping(uint16 => bytes32) registeredEmitters;
 
-        /// @dev Wormhole chain ID to Circle chain domain mapping
+        /// Wormhole chain ID to Circle chain domain mapping
         mapping(uint16 => uint32) chainIdToDomain;
 
-        /// @dev Wormhole chain ID to Circle chain domain mapping
+        /// Wormhole chain ID to Circle chain domain mapping
         mapping(uint32 => uint16) domainToChainId;
 
-        /// @dev verified Wormhole message hash to boolean
+        /// verified Wormhole message hash to boolean
         mapping(bytes32 => bool) consumedMessages;
 
-        /// @dev expected EVM chainid
+        /// expected EVM chain ID
         uint256 evmChain;
 
-        /// @dev storage gap for additional state variables in future versions
+        /// storage gap for additional state variables in future versions
         uint256[50] ______gap;
     }
 }


### PR DESCRIPTION
This PR does the following:
1) Removes natspec comments for non-public state variables
2) Uses `calldata` instead of `memory` in `redeemTokensWithPayload`
3) Adds a check for the zero address in `verifyEmitter`