### PR TITLE
evm: update registration to accept VAAs with target chain zero

### DIFF
--- a/evm/foundry.toml
+++ b/evm/foundry.toml
@@ -2,6 +2,7 @@
 solc_version = "0.8.19"
 optimizer = true
 optimizer_runs = 200
+evm_version = "paris"
 
 test = "forge-test"
 

--- a/evm/src/circle_integration/CircleIntegrationGovernance.sol
+++ b/evm/src/circle_integration/CircleIntegrationGovernance.sol
@@ -83,8 +83,10 @@ contract CircleIntegrationGovernance is CircleIntegrationGetters, ERC1967Upgrade
         bytes memory payload = verifyAndConsumeGovernanceMessage(encodedMessage, GOVERNANCE_REGISTER_EMITTER_AND_DOMAIN);
         require(payload.length == GOVERNANCE_REGISTER_EMITTER_AND_DOMAIN_LENGTH, "invalid governance payload length");
 
-        // registering emitters should only be relevant for this contract's chain ID
-        require(payload.toUint16(33) == chainId(), "invalid target chain");
+        // Registering emitters should only be relevant for this contract's chain ID,
+        // unless the target chain is 0 (which means all chains).
+        uint16 targetChainId = payload.toUint16(33);
+        require(targetChainId == chainId() || targetChainId == 0, "invalid target chain");
 
         // emitterChainId at byte 35
         uint16 emitterChainId = payload.toUint16(35);


### PR DESCRIPTION
The purpose of this PR is to allow registration VAAs with `targetChain == 0`. This will reduce the number of governance VAAs that are required to support a new CCTP deployment. 