### PR TITLE
solana: uptick anchor 0.30.0

### DIFF
--- a/solana/Anchor.toml
+++ b/solana/Anchor.toml
@@ -1,9 +1,9 @@
 [toolchain]
-anchor_version = "0.29.0"   # CLI
-solana_version = "1.16.27"
+anchor_version = "0.30.0"   # CLI
+solana_version = "1.18.10"
 
 [features]
-seeds = false
+resolution = false
 skip-lint = false
 
 [workspace]
@@ -25,7 +25,7 @@ wallet = "ts/tests/keys/pFCBP4bhqdSsrWUVTgqhPsLrfEdChBK17vgFM7TxjxQ.json"
 test = "npx ts-mocha -p ./tsconfig.json -t 1000000 ts/tests/[0-9]*.ts"
 
 [test]
-startup_wait = 30000
+startup_wait = 10000
 
 [test.validator]
 url = "https://api.devnet.solana.com"
@@ -43,16 +43,19 @@ address = "wcihrWf1s91vfukW7LW8ZvR1rzpeZ9BrtZ8oyPkWK5d"
 address = "4tTfYz2SqRcZWqyBk1yHyEPzHjoHNbUErQbifBkLmzbT"
 
 ### Wormhole Core Bridge Program (Testnet)
-[[test.validator.clone]]
+[[test.genesis]]
 address = "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"
+program = "ts/tests/artifacts/testnet_core_bridge.so"
 
 ### Circle Message Transmitter Program
-[[test.validator.clone]]
+[[test.genesis]]
 address = "CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd"
+program = "ts/tests/artifacts/testnet_cctp_message_transmitter.so"
 
 ### Circle Token Messenger Minter Program
-[[test.validator.clone]]
+[[test.genesis]]
 address = "CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3"
+program = "ts/tests/artifacts/testnet_cctp_token_messenger_minter.so"
 
 ### Mint -- USDC
 [[test.validator.account]]

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.12",
  "once_cell",
@@ -51,12 +51,11 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.12",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -73,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f619f1d04f53621925ba8a2e633ba5a6081f2ae14758cbb67f38fd823e0a3e"
+checksum = "dd7368e171b3a317885dc08ec0f74eed9d0ad6c726cc819593aed81440dca926"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -85,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f2a3e1df4685f18d12a943a9f2a7456305401af21a07c9fe076ef9ecd6e400"
+checksum = "f527df85a8cba3f2bea04e46ed71b66e525ea378c7fec538aa205f4520b73e31"
 dependencies = [
  "anchor-syn",
  "bs58 0.5.0",
@@ -98,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9423945cb55627f0b30903288e78baf6f62c6c8ab28fb344b6b25f1ffee3dca7"
+checksum = "3eb1dc1845cf8636c2e046a274ca074dabd3884ac8ed11cc4ed64b7e8ef5a318"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -109,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ed12720033cc3c3bf3cfa293349c2275cd5ab99936e33dd4bf283aaad3e241"
+checksum = "7f382e41514c59a77ffa7bb1a47df9a0359564a749b6934485c742c11962e540"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -120,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef4dc0371eba2d8c8b54794b0b0eb786a234a559b77593d6f80825b6d2c77a2"
+checksum = "473a122aeed3f6b666438236338d2ef7833ee5fdc5688e1baa80185d61088a53"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -132,20 +131,26 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b18c4f191331e078d4a6a080954d1576241c29c56638783322a18d308ab27e4f"
+checksum = "7f88c7ffe2eb40aeac43ffd0d74a6671581158aedfaa0552330a2ef92fa5c889"
 dependencies = [
+ "anchor-lang-idl",
  "anchor-syn",
+ "anyhow",
+ "bs58 0.5.0",
+ "heck",
+ "proc-macro2",
  "quote",
+ "serde_json",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de10d6e9620d3bcea56c56151cad83c5992f50d5960b3a9bebc4a50390ddc3c"
+checksum = "ed9b97c99dcec135aae0ff908c14bcfcd3e78cfc16a0c6f245135038f0e6d390"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -154,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e2e5be518ec6053d90a2a7f26843dbee607583c779e6c8395951b9739bdfbe"
+checksum = "bbece98f6ad9c37070edc0841326c9623a249346cd74f433e7cef69b14f7f31d"
 dependencies = [
  "anchor-syn",
  "borsh-derive-internal 0.10.3",
@@ -167,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecc31d19fa54840e74b7a979d44bcea49d70459de846088a1d71e87ba53c419"
+checksum = "8badbe2648bc99a85ee05a7a5f9512e5e2af8ffac71476a69350cb278057ac53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -178,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35da4785497388af0553586d55ebdc08054a8b1724720ef2749d313494f2b8ad"
+checksum = "e41feb9c1cd9f4b0fad1c004fc8f289183f3ce27e9db38fa6e434470c716fb1e"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -191,8 +196,9 @@ dependencies = [
  "anchor-derive-accounts",
  "anchor-derive-serde",
  "anchor-derive-space",
+ "anchor-lang-idl",
  "arrayref",
- "base64 0.13.1",
+ "base64 0.21.7",
  "bincode",
  "borsh 0.10.3",
  "bytemuck",
@@ -202,26 +208,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-spl"
-version = "0.29.0"
+name = "anchor-lang-idl"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
+checksum = "b29da81eae478b1bb846749b06b8a2cb9c6f9ed26ca793b0c916793fdf36adab"
+dependencies = [
+ "anchor-syn",
+ "anyhow",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcee54a30b27ea8317ca647759b5d9701a8c7caaaa0c922c6d3c306a7278a7a"
 dependencies = [
  "anchor-lang",
- "solana-program",
  "spl-associated-token-account",
+ "spl-pod",
  "spl-token",
  "spl-token-2022",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
 ]
 
 [[package]]
 name = "anchor-syn"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9101b84702fed2ea57bd22992f75065da5648017135b844283a2f6d74f27825"
+checksum = "ac53f2378bc08e89e20c2b893c01986ffd34cfbc69a17e35bd6f754753e9fdad"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
+ "cargo_toml",
  "heck",
  "proc-macro2",
  "quote",
@@ -398,12 +420,6 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -501,6 +517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
+dependencies = [
+ "borsh-derive 1.4.0",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "borsh-derive"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +550,20 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "syn_derive",
 ]
 
 [[package]]
@@ -603,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -628,6 +668,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cargo_toml"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+dependencies = [
+ "serde",
+ "toml 0.8.12",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +692,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -957,7 +1013,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -966,7 +1022,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.5",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -1326,7 +1382,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -1421,7 +1477,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1431,7 +1487,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1706,6 +1794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,17 +1900,13 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.17.20"
+version = "1.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380a5173027b9d70fa033272ebc8ffe8e59c64274109ac99b05578a4c9434215"
+checksum = "3b8177685ab2bc8cc8b3bf63aa1eaa0580d5af850ecefac323ca1c2473085d77"
 dependencies = [
- "ahash 0.8.5",
- "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
  "bv",
- "byteorder",
- "cc",
  "either",
  "generic-array",
  "im",
@@ -1818,7 +1917,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json",
  "sha2 0.10.8",
  "solana-frozen-abi-macro",
  "subtle",
@@ -1827,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.17.20"
+version = "1.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1017a631a72e211f8bd78e707c9424fb0ef074f3df5bb7b6baef6912a3b1b6b"
+checksum = "4a68241cad17b74c6034a68ba4890632d409a2c886e7bead9c1e1432befdb7c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1839,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.17.20"
+version = "1.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcfc4dc59c2f64b0d78b27e5db0238e4f6be852454b0f915bd1f58806fe08c3"
+checksum = "fea560989ef67ba4a1a0fd62a248721f1aa5bac8fa5ede9ccf4fe9ee484ccadf"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1850,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.17.20"
+version = "1.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e882d2ae4903aec8657d18075897cba532155d8f49a0aa39acc0f86fee8c5697"
+checksum = "8bddf573103c890b4ab8f9a6641d4f969d4148bce9a451c263f4a62afa949fae"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1864,6 +1962,7 @@ dependencies = [
  "blake3",
  "borsh 0.10.3",
  "borsh 0.9.3",
+ "borsh 1.4.0",
  "bs58 0.4.0",
  "bv",
  "bytemuck",
@@ -1881,7 +1980,7 @@ dependencies = [
  "log",
  "memoffset",
  "num-bigint",
- "num-derive 0.3.3",
+ "num-derive 0.4.2",
  "num-traits",
  "parking_lot",
  "rand 0.8.5",
@@ -1904,15 +2003,15 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.17.20"
+version = "1.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b191352781d621b08b3513b02857c8e89f891a8e2aeeeecff977f9819e1a7d5"
+checksum = "08b24b06fa176209ddb2a2f8172a00b07e8a3b18229fbfc49f1eb3ce6ad11ff1"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
  "bincode",
  "bitflags 2.4.2",
- "borsh 0.10.3",
+ "borsh 1.4.0",
  "bs58 0.4.0",
  "bytemuck",
  "byteorder",
@@ -1929,9 +2028,9 @@ dependencies = [
  "libsecp256k1",
  "log",
  "memmap2",
- "num-derive 0.3.3",
+ "num-derive 0.4.2",
  "num-traits",
- "num_enum 0.6.1",
+ "num_enum 0.7.2",
  "pbkdf2 0.11.0",
  "qstring",
  "qualifier_attr",
@@ -1946,6 +2045,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "sha3 0.10.8",
+ "siphasher",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
@@ -1958,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.17.20"
+version = "1.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a7d5483adb2e54e79160ff03fb20fc93e537cc06bef0fc964e2e6e3bbefdbd"
+checksum = "869483c05f18d37d4d95a08d9e05e00a4f76a8c8349aeedeee9ba2d013cbacde"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -1970,10 +2070,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-zk-token-sdk"
-version = "1.17.20"
+name = "solana-security-txt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bfe4443f550d37b0055d3dade5ae0dc951d8f80b9f58f1043b699fe9a2f326"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
+name = "solana-zk-token-sdk"
+version = "1.18.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459c27f7b954798677d8243aa53b8080cfb314ecfecbf8889a5a65c91ad11fee"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",
@@ -1985,7 +2091,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "merlin",
- "num-derive 0.3.3",
+ "num-derive 0.4.2",
  "num-traits",
  "rand 0.7.3",
  "serde",
@@ -2000,12 +2106,12 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "2.2.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385e31c29981488f2820b2022d8e731aae3b02e6e18e2fd854e4c9a94dc44fc3"
+checksum = "a2e688554bac5838217ffd1fab7845c573ff106b6336bf7d290db7c98d5a8efd"
 dependencies = [
  "assert_matches",
- "borsh 0.10.3",
+ "borsh 1.4.0",
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
@@ -2016,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
+checksum = "34d1814406e98b08c5cd02c1126f83fd407ad084adce0b05fda5730677822eac"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2027,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-derive"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fd7858fc4ff8fb0e34090e41d7eb06a823e1057945c26d480bfc21d2338a93"
+checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
@@ -2038,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fea7be851bd98d10721782ea958097c03a0c2a07d8d4997041d0ece6319a63"
+checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2060,11 +2166,11 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
+checksum = "046ce669f48cf2eca1ec518916d8725596bfb655beb1c74374cf71dc6cb773c9"
 dependencies = [
- "borsh 0.10.3",
+ "borsh 1.4.0",
  "bytemuck",
  "solana-program",
  "solana-zk-token-sdk",
@@ -2073,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
+checksum = "5528f4dfa2a905012007999526955c79162c09668c69ad3c3f2ddfbd0b2984a4"
 dependencies = [
  "num-derive 0.4.2",
  "num-traits",
@@ -2086,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1845dfe71fd68f70382232742e758557afe973ae19e6c06807b2c30f5d5cb474"
+checksum = "641aa3116b1d58481e921b5d41dafc26a67bd488cb288330dbde004641764dd4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2098,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
+checksum = "cace91ba08984a41556efe49cbf2edca4db2f577b649da7827d3621161784bf8"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2127,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.9.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
+checksum = "e5412f99ae7ee6e0afde00defaa354e6228e47e30c0e3adf553e2e01e6abb584"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2137,10 +2243,12 @@ dependencies = [
  "num-traits",
  "num_enum 0.7.2",
  "solana-program",
+ "solana-security-txt",
  "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
  "spl-token",
+ "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
@@ -2148,12 +2256,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-token-metadata-interface"
-version = "0.2.0"
+name = "spl-token-group-interface"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
+checksum = "d419b5cfa3ee8e0f2386fd7e02a33b3ec8a7db4a9c7064a2ea24849dc4a273b6"
 dependencies = [
- "borsh 0.10.3",
+ "bytemuck",
+ "solana-program",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-program-error",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30179c47e93625680dabb620c6e7931bd12d62af390f447bc7beb4a3a9b5feee"
+dependencies = [
+ "borsh 1.4.0",
  "solana-program",
  "spl-discriminator",
  "spl-pod",
@@ -2163,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.3.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
+checksum = "66a98359769cd988f7b35c02558daa56d496a7e3bd8626e61f90a7c757eedb9b"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2179,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
+checksum = "422ce13429dbd41d2cee8a73931c05fda0b0c8ca156a8b0c19445642550bb61a"
 dependencies = [
  "bytemuck",
  "solana-program",
@@ -2222,6 +2343,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2297,10 +2430,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.9",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2310,7 +2458,31 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.39",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.5.39",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.6",
 ]
 
 [[package]]
@@ -2540,24 +2712,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wormhole-cctp-solana"
-version = "0.1.0-alpha.8"
+version = "0.3.0-alpha.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "cfg-if",
  "hex",
  "hex-literal",
  "ruint",
  "solana-program",
  "wormhole-io",
  "wormhole-raw-vaas",
+ "wormhole-solana-consts",
+ "wormhole-solana-utils",
  "wormhole-solana-vaas",
 ]
 
 [[package]]
 name = "wormhole-circle-integration-solana"
-version = "0.1.0-alpha.8"
+version = "0.3.0-alpha.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2572,31 +2754,41 @@ dependencies = [
 
 [[package]]
 name = "wormhole-io"
-version = "0.1.3"
+version = "0.3.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021a14ea7bcef9517ed9f81d4466c4a663dd90e726c5724707a976fa83ad8f3"
+checksum = "b9a873b44870f1f20c68683a83f0350a34893f94f04149cbce494f7049e6101e"
 
 [[package]]
 name = "wormhole-raw-vaas"
-version = "0.2.0-alpha.2"
+version = "0.3.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b8fed51f54543a57b009ce057df3380269c70971d4d096cc9f5dcc2cb1fdb7"
+checksum = "b0e6f86cd1e555a969ffc6fa1f3306da9d45557d1bec91959474b70fcee8c8ac"
 
 [[package]]
 name = "wormhole-solana-consts"
-version = "0.2.0-alpha.11"
+version = "0.3.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037dcc895cb45b18d898ccb52358c6dfa02a68bd99f0c68d883c15bb9fb8b423"
+checksum = "76f5547b17820c264bc805be3408ff2d435f30995a5b3023ba6095f74d01ce74"
 dependencies = [
  "cfg-if",
  "solana-program",
 ]
 
 [[package]]
-name = "wormhole-solana-vaas"
-version = "0.2.0-alpha.16"
+name = "wormhole-solana-utils"
+version = "0.3.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfedc5399e3f53c32f1d5690fb866389bf135cac754d4f32df8227da621a6b1"
+checksum = "5372a25072a8d82772ee912a949ff6ee182f7ea38a88d458b6ee23b0b32e5235"
+dependencies = [
+ "anchor-lang",
+ "solana-program",
+]
+
+[[package]]
+name = "wormhole-solana-vaas"
+version = "0.3.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd606eb259033e40b74e8501e1d4a90276a595582765a6fd49bbeec1ab3fbe1"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.3",

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0-alpha.8"
+version = "0.3.0-alpha.0"
 authors = ["Wormhole Contributors"]
 license = "Apache-2.0"
 homepage = "https://wormhole.com"
@@ -15,22 +15,23 @@ repository = "https://github.com/wormhole-foundation/wormhole-circle-integration
 
 [workspace.dependencies.wormhole-cctp-solana]
 path = "modules/wormhole-cctp"
-default-features = false
 
 [workspace.dependencies.wormhole-raw-vaas]
-version = "0.2.0-alpha.2"
+version = "0.3.0-alpha.0"
 
 [workspace.dependencies.wormhole-solana-vaas]
-version = "0.2.0-alpha.16"
+version = "0.3.0-alpha.0"
 features = ["anchor"]
 
 [workspace.dependencies.anchor-lang]
-version = ">=0.29.0,<0.31.0"
+version = ">=0.29.0"
 features = ["derive", "init-if-needed"]
 
 [workspace.dependencies]
-wormhole-io = "0.1.3"
-anchor-spl = ">=0.29.0,<0.31.0"
+wormhole-solana-consts = "0.3.0-alpha.0"
+wormhole-solana-utils = "0.3.0-alpha.0"
+wormhole-io = "0.3.0-alpha.0"
+anchor-spl = ">=0.29.0"
 solana-program = "1.17.20"
 hex = "0.4.3"
 ruint = "1.9.0"

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -1,6 +1,3 @@
-SOLANA_CLI="v1.16.16"
-ANCHOR_CLI="v0.28.0"
-
 out_mainnet=artifacts-mainnet
 out_testnet=artifacts-testnet
 
@@ -12,31 +9,32 @@ check:
 	cargo check --all-features
 
 clean:
+	cargo clean
 	anchor clean
 	rm -rf node_modules artifacts-mainnet artifacts-testnet ts/tests/artifacts
 
 node_modules:
 	npm ci
 
-prune_idl: node_modules ts/scripts/pruneIdlTypes.ts
-	cd ts/scripts && npx ts-node pruneIdlTypes.ts
-
 build: $(out_$(NETWORK))
 $(out_$(NETWORK)):
 ifdef out_$(NETWORK)
-	anchor build -p wormhole_circle_integration_solana --arch sbf -- --features "$(NETWORK),no-idl" -- --no-default-features
+	anchor build --no-idl -- --features $(NETWORK)
 	mkdir -p $(out_$(NETWORK))
 	cp target/deploy/*.so $(out_$(NETWORK))/
 endif
 
-test: node_modules
-	cargo test --all-features
-	anchor build -p wormhole_circle_integration_solana --arch sbf -- --features testnet -- --no-default-features
-	mkdir -p ts/tests/artifacts && cp target/deploy/wormhole_circle_integration_solana.so ts/tests/artifacts/testnet_wormhole_circle_integration_solana.so
+test: node_modules ts/tests/artifacts
+	anchor build --no-idl -- --features testnet
+	cp target/deploy/wormhole_circle_integration_solana.so ts/tests/artifacts/testnet_wormhole_circle_integration_solana.so
 	solana program dump -u m worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth ts/tests/artifacts/mainnet_core_bridge.so
-	anchor build --arch sbf -- --features integration-test -- --no-default-features
-	$(MAKE) prune_idl
-	anchor test --skip-build
+	bash sh/run_anchor_test.sh
+
+ts/tests/artifacts:
+	mkdir -p ts/tests/artifacts
+
+cargo-test:
+	cargo clean && cargo test --all-features
 
 lint:
 	cargo fmt --check

--- a/solana/modules/wormhole-cctp/Cargo.toml
+++ b/solana/modules/wormhole-cctp/Cargo.toml
@@ -15,12 +15,16 @@ crate-type = ["cdylib", "lib"]
 default = ["cpi"]
 client = []
 cpi = ["dep:anchor-spl", "dep:solana-program"]
-mainnet = ["wormhole-solana-vaas/mainnet"]
-testnet = ["wormhole-solana-vaas/testnet"]
+mainnet = ["wormhole-solana-consts/mainnet", "wormhole-solana-vaas/mainnet"]
+testnet = ["wormhole-solana-consts/testnet", "wormhole-solana-vaas/testnet"]
+localnet = ["wormhole-solana-consts/localnet", "wormhole-solana-vaas/localnet"]
+idl-build = ["mainnet", "anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
 wormhole-io.workspace = true
 wormhole-raw-vaas.workspace = true
+wormhole-solana-consts.workspace = true
+wormhole-solana-utils.workspace = true
 wormhole-solana-vaas.workspace = true
 
 anchor-lang.workspace = true
@@ -29,8 +33,6 @@ solana-program = { optional = true, workspace = true }
 
 hex.workspace = true
 ruint.workspace = true
-
-cfg-if.workspace = true
 
 [dev-dependencies]
 hex-literal.workspace = true

--- a/solana/modules/wormhole-cctp/src/cctp/message_transmitter_program/mod.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/message_transmitter_program/mod.rs
@@ -4,19 +4,4 @@ pub mod cpi;
 mod state;
 pub use state::*;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "mainnet")] {
-        // Placeholder for real address
-        anchor_lang::declare_id!("CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd");
-    } else if #[cfg(feature = "testnet")] {
-        anchor_lang::declare_id!("CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd");
-    }
-}
-
-pub struct MessageTransmitter {}
-
-impl anchor_lang::Id for MessageTransmitter {
-    fn id() -> solana_program::pubkey::Pubkey {
-        ID
-    }
-}
+anchor_lang::declare_id!(crate::cctp::MESSAGE_TRANSMITTER_PROGRAM_ID);

--- a/solana/modules/wormhole-cctp/src/cctp/message_transmitter_program/state/message_transmitter_config.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/message_transmitter_program/state/message_transmitter_config.rs
@@ -15,12 +15,8 @@ pub struct MessageTransmitterConfig {
     pub next_available_nonce: u64,
 }
 
-impl anchor_lang::Discriminator for MessageTransmitterConfig {
-    const DISCRIMINATOR: [u8; 8] = [71, 40, 180, 142, 19, 203, 35, 252];
-}
-
-impl Owner for MessageTransmitterConfig {
-    fn owner() -> Pubkey {
-        crate::cctp::message_transmitter_program::ID
-    }
-}
+wormhole_solana_utils::impl_anchor_account_readonly!(
+    MessageTransmitterConfig,
+    crate::cctp::message_transmitter_program::ID,
+    [71, 40, 180, 142, 19, 203, 35, 252]
+);

--- a/solana/modules/wormhole-cctp/src/cctp/mod.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/mod.rs
@@ -1,3 +1,10 @@
 pub mod message_transmitter_program;
 
 pub mod token_messenger_minter_program;
+
+use solana_program::{pubkey, pubkey::Pubkey};
+
+pub const MESSAGE_TRANSMITTER_PROGRAM_ID: Pubkey =
+    pubkey!("CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd");
+pub const TOKEN_MESSENGER_MINTER_PROGRAM_ID: Pubkey =
+    pubkey!("CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3");

--- a/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/cpi/deposit_for_burn_with_caller.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/cpi/deposit_for_burn_with_caller.rs
@@ -92,7 +92,7 @@ pub fn deposit_for_burn_with_caller<'info>(
 
     solana_program::program::invoke_signed(
         &solana_program::instruction::Instruction {
-            program_id: crate::cctp::token_messenger_minter_program::ID,
+            program_id: crate::cctp::TOKEN_MESSENGER_MINTER_PROGRAM_ID,
             accounts: ctx.to_account_metas(None),
             data: (ANCHOR_IX_SELECTOR, args).try_to_vec()?,
         },

--- a/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/mod.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/mod.rs
@@ -4,19 +4,4 @@ pub mod cpi;
 mod state;
 pub use state::*;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "mainnet")] {
-        // Placeholder for real address
-        anchor_lang::declare_id!("CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3");
-    } else if #[cfg(feature = "testnet")] {
-        anchor_lang::declare_id!("CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3");
-    }
-}
-
-pub struct TokenMessengerMinter {}
-
-impl anchor_lang::Id for TokenMessengerMinter {
-    fn id() -> solana_program::pubkey::Pubkey {
-        ID
-    }
-}
+anchor_lang::declare_id!(crate::cctp::TOKEN_MESSENGER_MINTER_PROGRAM_ID);

--- a/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/state/local_token.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/state/local_token.rs
@@ -17,12 +17,8 @@ impl LocalToken {
     pub const SEED_PREFIX: &'static [u8] = b"local_token";
 }
 
-impl anchor_lang::Discriminator for LocalToken {
-    const DISCRIMINATOR: [u8; 8] = [159, 131, 58, 170, 193, 84, 128, 182];
-}
-
-impl Owner for LocalToken {
-    fn owner() -> Pubkey {
-        crate::cctp::token_messenger_minter_program::ID
-    }
-}
+wormhole_solana_utils::impl_anchor_account_readonly!(
+    LocalToken,
+    crate::cctp::TOKEN_MESSENGER_MINTER_PROGRAM_ID,
+    [159, 131, 58, 170, 193, 84, 128, 182]
+);

--- a/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/state/remote_token_messenger.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/state/remote_token_messenger.rs
@@ -10,12 +10,8 @@ impl RemoteTokenMessenger {
     pub const SEED_PREFIX: &'static [u8] = b"remote_token_messenger";
 }
 
-impl anchor_lang::Discriminator for RemoteTokenMessenger {
-    const DISCRIMINATOR: [u8; 8] = [105, 115, 174, 34, 95, 233, 138, 252];
-}
-
-impl Owner for RemoteTokenMessenger {
-    fn owner() -> Pubkey {
-        crate::cctp::token_messenger_minter_program::ID
-    }
-}
+wormhole_solana_utils::impl_anchor_account_readonly!(
+    RemoteTokenMessenger,
+    crate::cctp::TOKEN_MESSENGER_MINTER_PROGRAM_ID,
+    [105, 115, 174, 34, 95, 233, 138, 252]
+);

--- a/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/state/token_pair.rs
+++ b/solana/modules/wormhole-cctp/src/cctp/token_messenger_minter_program/state/token_pair.rs
@@ -12,12 +12,8 @@ impl TokenPair {
     pub const SEED_PREFIX: &'static [u8] = b"token_pair";
 }
 
-impl anchor_lang::Discriminator for TokenPair {
-    const DISCRIMINATOR: [u8; 8] = [17, 214, 45, 176, 229, 149, 197, 71];
-}
-
-impl Owner for TokenPair {
-    fn owner() -> Pubkey {
-        crate::cctp::token_messenger_minter_program::ID
-    }
-}
+wormhole_solana_utils::impl_anchor_account_readonly!(
+    TokenPair,
+    crate::cctp::TOKEN_MESSENGER_MINTER_PROGRAM_ID,
+    [17, 214, 45, 176, 229, 149, 197, 71]
+);

--- a/solana/modules/wormhole-cctp/src/error.rs
+++ b/solana/modules/wormhole-cctp/src/error.rs
@@ -5,6 +5,9 @@
 
 #[anchor_lang::error_code(offset = 0)]
 pub enum WormholeCctpError {
+    #[msg("Invalid VAA account")]
+    InvalidVaa = 0xffff0000,
+
     #[msg("Cannot parse VAA payload as Wormhole CCTP message")]
     CannotParseMessage = 0xffff0001,
 
@@ -25,4 +28,7 @@ pub enum WormholeCctpError {
 
     #[msg("Encoded mint recipient does not match mint recipient token account")]
     InvalidMintRecipient = 0xffff0014,
+
+    #[msg("Deposit message exceeds u16::MAX")]
+    DepositMessageTooLarge = 0xffff0080,
 }

--- a/solana/modules/wormhole-cctp/src/utils/accounts.rs
+++ b/solana/modules/wormhole-cctp/src/utils/accounts.rs
@@ -1,99 +1,35 @@
-use anchor_lang::{prelude::*, Discriminator};
+#[macro_export]
+macro_rules! impl_anchor_account_readonly {
+    ($anchor_acc:ty, $owner:expr, $disc:expr) => {
+        impl anchor_lang::Owner for $anchor_acc {
+            fn owner() -> anchor_lang::solana_program::pubkey::Pubkey {
+                $owner
+            }
+        }
+        impl anchor_lang::Discriminator for $anchor_acc {
+            const DISCRIMINATOR: [u8; 8] = $disc;
+        }
 
-/// Wrapper for external account schemas, where an Anchor [Discriminator] and [Owner] are defined.
-#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone)]
-pub struct ExternalAccount<T>(T)
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner;
+        impl anchor_lang::AccountDeserialize for $anchor_acc {
+            fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+                require!(
+                    buf.len() >= 8,
+                    anchor_lang::error::ErrorCode::AccountDidNotDeserialize
+                );
+                require!(
+                    buf[..8] == <Self as anchor_lang::Discriminator>::DISCRIMINATOR,
+                    anchor_lang::error::ErrorCode::AccountDiscriminatorMismatch,
+                );
+                Self::try_deserialize_unchecked(buf)
+            }
 
-impl<T> AccountDeserialize for ExternalAccount<T>
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner,
-{
-    fn try_deserialize(buf: &mut &[u8]) -> Result<Self> {
-        require!(buf.len() >= 8, ErrorCode::AccountDidNotDeserialize);
-        require!(
-            buf[..8] == T::DISCRIMINATOR,
-            ErrorCode::AccountDiscriminatorMismatch,
-        );
-        Self::try_deserialize_unchecked(buf)
-    }
+            fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self> {
+                Self::deserialize(&mut &buf[8..]).map_err(Into::into)
+            }
+        }
 
-    fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self> {
-        Ok(Self(T::deserialize(&mut &buf[8..])?))
-    }
+        impl anchor_lang::AccountSerialize for $anchor_acc {}
+    };
 }
 
-impl<T> AccountSerialize for ExternalAccount<T> where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner
-{
-}
-
-impl<T> Owner for ExternalAccount<T>
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner,
-{
-    fn owner() -> Pubkey {
-        T::owner()
-    }
-}
-
-impl<T> std::ops::Deref for ExternalAccount<T>
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner,
-{
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-/// Wrapper for external account schemas, where an Anchor [Discriminator] and [Owner] are defined.
-#[derive(Debug, AnchorSerialize, AnchorDeserialize, Clone)]
-pub struct BoxedExternalAccount<T>(Box<T>)
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner;
-
-impl<T> AccountDeserialize for BoxedExternalAccount<T>
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner,
-{
-    fn try_deserialize(buf: &mut &[u8]) -> Result<Self> {
-        require!(buf.len() >= 8, ErrorCode::AccountDidNotDeserialize);
-        require!(
-            buf[..8] == T::DISCRIMINATOR,
-            ErrorCode::AccountDiscriminatorMismatch,
-        );
-        Self::try_deserialize_unchecked(buf)
-    }
-
-    fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self> {
-        Ok(Self(Box::new(T::deserialize(&mut &buf[8..])?)))
-    }
-}
-
-impl<T> AccountSerialize for BoxedExternalAccount<T> where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner
-{
-}
-
-impl<T> Owner for BoxedExternalAccount<T>
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner,
-{
-    fn owner() -> Pubkey {
-        T::owner()
-    }
-}
-
-impl<T> std::ops::Deref for BoxedExternalAccount<T>
-where
-    T: AnchorSerialize + AnchorDeserialize + Clone + Discriminator + Owner,
-{
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub use impl_anchor_account_readonly;

--- a/solana/modules/wormhole-cctp/src/utils/mod.rs
+++ b/solana/modules/wormhole-cctp/src/utils/mod.rs
@@ -1,5 +1,5 @@
-mod accounts;
-pub use accounts::*;
+// mod accounts;
+// pub use accounts::*;
 
 mod zero_copy;
 pub use zero_copy::*;

--- a/solana/modules/wormhole-cctp/src/wormhole/core_bridge_program/mod.rs
+++ b/solana/modules/wormhole-cctp/src/wormhole/core_bridge_program/mod.rs
@@ -5,23 +5,7 @@ pub mod state;
 
 use anchor_lang::prelude::*;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "localnet")] {
-        declare_id!("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o");
-    } else if #[cfg(feature = "mainnet")] {
-        declare_id!("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth");
-    } else if #[cfg(feature = "testnet")] {
-        declare_id!("3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5");
-    }
-}
-
-pub struct CoreBridge;
-
-impl Id for CoreBridge {
-    fn id() -> Pubkey {
-        ID
-    }
-}
+declare_id!(wormhole_solana_consts::CORE_BRIDGE_PROGRAM_ID);
 
 /// Representation of Solana's commitment levels. This enum is not exhaustive because Wormhole only
 /// considers these two commitment levels in its Guardian observation.

--- a/solana/package-lock.json
+++ b/solana/package-lock.json
@@ -10,11 +10,12 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@certusone/wormhole-sdk": "^0.10.10",
-        "@coral-xyz/anchor": "^0.29.0",
+        "@coral-xyz/anchor": "^0.30.0",
         "@solana/spl-token": "^0.3.8",
         "@solana/web3.js": "^1.87.3",
         "@types/chai": "^4.3.9",
         "@types/mocha": "^10.0.3",
+        "anchor-0.29.0": "npm:@coral-xyz/anchor@^0.29.0",
         "chai": "^4.3.10",
         "dotenv": "^16.3.1",
         "ethers": "^5.7.2",
@@ -272,12 +273,12 @@
       }
     },
     "node_modules/@coral-xyz/anchor": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
-      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.30.0.tgz",
+      "integrity": "sha512-qreDh5ztiRHVnCbJ+RS70NJ6aSTPBYDAgFeQ7Z5QvaT5DcDIhNyt4onOciVz2ieIE1XWePOJDDu9SbNvPGBkvQ==",
       "dev": true,
       "dependencies": {
-        "@coral-xyz/borsh": "^0.29.0",
+        "@coral-xyz/borsh": "^0.30.0",
         "@noble/hashes": "^1.3.1",
         "@solana/web3.js": "^1.68.0",
         "bn.js": "^5.1.2",
@@ -297,9 +298,9 @@
       }
     },
     "node_modules/@coral-xyz/borsh": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
-      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.30.0.tgz",
+      "integrity": "sha512-OrcV+7N10cChhgDRUxM4iEIuwxUHHs52XD85R8cFCUqE0vbLYrcoPPPs+VF6kZ9DhdJGVW2I6DHJOp5TykyZog==",
       "dev": true,
       "dependencies": {
         "bn.js": "^5.1.2",
@@ -2381,6 +2382,48 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/anchor-0.29.0": {
+      "name": "@coral-xyz/anchor",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
+      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
+      "dev": true,
+      "dependencies": {
+        "@coral-xyz/borsh": "^0.29.0",
+        "@noble/hashes": "^1.3.1",
+        "@solana/web3.js": "^1.68.0",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^6.3.0",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/anchor-0.29.0/node_modules/@coral-xyz/borsh": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
+      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
       }
     },
     "node_modules/ansi-colors": {

--- a/solana/package.json
+++ b/solana/package.json
@@ -14,11 +14,12 @@
   "homepage": "https://github.com/wormhole-foundation/wormhole-circle-integration#readme",
   "devDependencies": {
     "@certusone/wormhole-sdk": "^0.10.10",
-    "@coral-xyz/anchor": "^0.29.0",
+    "@coral-xyz/anchor": "^0.30.0",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.87.3",
     "@types/chai": "^4.3.9",
     "@types/mocha": "^10.0.3",
+    "anchor-0.29.0": "npm:@coral-xyz/anchor@^0.29.0",
     "chai": "^4.3.10",
     "dotenv": "^16.3.1",
     "ethers": "^5.7.2",

--- a/solana/programs/circle-integration/Cargo.toml
+++ b/solana/programs/circle-integration/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 crate-type = ["cdylib", "lib"]
 
 [features]
-default = ["mainnet", "no-idl", "cpi"]
+default = ["no-idl"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
@@ -20,6 +20,7 @@ cpi = ["no-entrypoint"]
 testnet = ["wormhole-cctp-solana/testnet"]
 mainnet = ["wormhole-cctp-solana/mainnet"]
 integration-test = ["mainnet"]
+idl-build = ["testnet", "anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
 wormhole-cctp-solana = { workspace = true, features = ["cpi"] }

--- a/solana/programs/circle-integration/src/processor/governance/register_emitter_and_domain.rs
+++ b/solana/programs/circle-integration/src/processor/governance/register_emitter_and_domain.rs
@@ -5,7 +5,6 @@ use crate::{
 use anchor_lang::prelude::*;
 use wormhole_cctp_solana::{
     cctp::token_messenger_minter_program,
-    utils::ExternalAccount,
     wormhole::{VaaAccount, SOLANA_CHAIN},
 };
 use wormhole_raw_vaas::cctp::CircleIntegrationGovPayload;
@@ -22,7 +21,7 @@ pub struct RegisterEmitterAndDomain<'info> {
     custodian: Account<'info, Custodian>,
 
     /// CHECK: We will be performing zero-copy deserialization in the instruction handler.
-    vaa: AccountInfo<'info>,
+    vaa: UncheckedAccount<'info>,
 
     #[account(
         init,
@@ -56,8 +55,7 @@ pub struct RegisterEmitterAndDomain<'info> {
         bump,
         seeds::program = token_messenger_minter_program::id(),
     )]
-    remote_token_messenger:
-        Account<'info, ExternalAccount<token_messenger_minter_program::RemoteTokenMessenger>>,
+    remote_token_messenger: Account<'info, token_messenger_minter_program::RemoteTokenMessenger>,
 
     system_program: Program<'info, System>,
 }

--- a/solana/programs/circle-integration/src/processor/governance/upgrade_contract.rs
+++ b/solana/programs/circle-integration/src/processor/governance/upgrade_contract.rs
@@ -110,6 +110,7 @@ pub fn upgrade_contract(ctx: Context<UpgradeContract>) -> Result<()> {
 }
 
 fn handle_access_control(ctx: &Context<UpgradeContract>) -> Result<()> {
+    msg!("wtf");
     msg!("okay... {:?}", ctx.accounts.vaa.key());
     let vaa = VaaAccount::load(&ctx.accounts.vaa)?;
     msg!("and...");

--- a/solana/programs/circle-integration/src/processor/redeem_tokens_with_payload.rs
+++ b/solana/programs/circle-integration/src/processor/redeem_tokens_with_payload.rs
@@ -7,7 +7,6 @@ use anchor_spl::token;
 use wormhole_cctp_solana::{
     cctp::{message_transmitter_program, token_messenger_minter_program},
     cpi::ReceiveMessageArgs,
-    utils::ExternalAccount,
     wormhole::VaaAccount,
 };
 
@@ -120,7 +119,7 @@ pub struct RedeemTokensWithPayload<'info> {
         bump = local_token.bump,
         seeds::program = token_messenger_minter_program,
     )]
-    local_token: Account<'info, ExternalAccount<token_messenger_minter_program::LocalToken>>,
+    local_token: Account<'info, token_messenger_minter_program::LocalToken>,
 
     /// CHECK: Seeds must be \["token_pair", remote_domain.to_string(), remote_token_address\] (CCTP
     /// Token Messenger Minter program).
@@ -133,9 +132,14 @@ pub struct RedeemTokensWithPayload<'info> {
     /// CHECK: Seeds must be \["__event_authority"\] (CCTP Token Messenger Minter program).
     token_messenger_minter_event_authority: UncheckedAccount<'info>,
 
-    token_messenger_minter_program:
-        Program<'info, token_messenger_minter_program::TokenMessengerMinter>,
-    message_transmitter_program: Program<'info, message_transmitter_program::MessageTransmitter>,
+    /// CHECK: Must equal CCTP Token Messenger Minter program ID.
+    #[account(address = token_messenger_minter_program::id())]
+    token_messenger_minter_program: UncheckedAccount<'info>,
+
+    /// CHECK: Must equal CCTP Message Transmitter program ID.
+    #[account(address = message_transmitter_program::id())]
+    message_transmitter_program: UncheckedAccount<'info>,
+
     token_program: Program<'info, token::Token>,
     system_program: Program<'info, System>,
 }

--- a/solana/sh/run_anchor_test.sh
+++ b/solana/sh/run_anchor_test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+### I really hope this is just a temporary script. We cannot specify clone-upgradable-programs in
+### Anchor.toml, so we need to clone the upgradeable programs manually.
+
+if test -f .validator_pid; then
+    echo "Killing existing validator"
+    kill $(cat .validator_pid)
+    rm .validator_pid
+fi
+
+rm -rf .anchor/test-ledger
+mkdir -p .anchor
+
+anchor build -- --features integration-test
+
+### Start up the validator.
+echo "Starting solana-test-validator"
+
+solana-test-validator \
+    --ledger \
+    .anchor/test-ledger \
+    --mint \
+    pFCBP4bhqdSsrWUVTgqhPsLrfEdChBK17vgFM7TxjxQ \
+    --bpf-program \
+    Wormho1eCirc1e1ntegration111111111111111111 \
+    target/deploy/wormhole_circle_integration_solana.so \
+    --bpf-program \
+    worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth \
+    ts/tests/artifacts/mainnet_core_bridge.so \
+    --account \
+    4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU \
+    ts/tests/accounts/usdc_mint.json \
+    --account \
+    6s9vuDVXZsJY1Qp29cFxKgbSmpTH2QWnrjZzPHWmFXCz \
+    ts/tests/accounts/usdc_payer_token.json \
+    --account \
+    Afgq3BHEfCE7d78D2XE9Bfyu2ieDqvE24xX8KDwreBms \
+    ts/tests/accounts/token_messenger_minter/token_messenger.json \
+    --account \
+    DBD8hAwLDRQkTsu6EqviaYNGKPnsAMmQonxf7AH8ZcFY \
+    ts/tests/accounts/token_messenger_minter/token_minter.json \
+    --account \
+    AEfKU8wHGtYgsXpymQ6e1cGHJJeKqCj95pw82iyRUKEs \
+    ts/tests/accounts/token_messenger_minter/usdc_custody_token.json \
+    --account \
+    4xt9P42CcMHXAgvemTnzineHp6owfGUcrg1xD9V7mdk1 \
+    ts/tests/accounts/token_messenger_minter/usdc_local_token.json \
+    --account \
+    ADcG1d7znq6wR73BJgEh7dR4vTJcETLLyfXMNZjJVwk4 \
+    ts/tests/accounts/token_messenger_minter/usdc_token_pair.json \
+    --account \
+    Hazwi3jFQtLKc2ughi7HFXPkpDeso7DQaMR9Ks4afh3j \
+    ts/tests/accounts/token_messenger_minter/ethereum_remote_token_messenger.json \
+    --account \
+    BWyFzH6LsnmDAaDWbGsriQ9SiiKq1CF6pbH4Ye3kzSBV \
+    ts/tests/accounts/token_messenger_minter/misconfigured_remote_token_messenger.json \
+    --account \
+    BWrwSWjbikT3H7qHAkUEbLmwDQoB4ZDJ4wcSEhSPTZCu \
+    ts/tests/accounts/message_transmitter/message_transmitter_config.json \
+    --account \
+    6bi4JGDoRwUs9TYBuvoA7dUVyikTJDrJsJU1ew6KVLiu \
+    ts/tests/accounts/core_bridge_testnet/config.json \
+    --account \
+    7s3a1ycs16d6SNDumaRtjcoyMaTDZPavzgsmS3uUZYWX \
+    ts/tests/accounts/core_bridge_testnet/fee_collector.json \
+    --account \
+    dxZtypiKT5D9LYzdPxjvSZER9MgYfeRVU5qpMTMTRs4 \
+    ts/tests/accounts/core_bridge_testnet/guardian_set_0.json \
+    --account \
+    2yVjuQwpsvdsrywzsJJVs9Ueh4zayyo5DYJbBNc3DDpn \
+    ts/tests/accounts/core_bridge_mainnet/config.json \
+    --account \
+    9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxeintHy \
+    ts/tests/accounts/core_bridge_mainnet/fee_collector.json \
+    --account \
+    DS7qfSAgYsonPpKoAjcGhX9VFjXdGkiHjEDkTidf8H2P \
+    ts/tests/accounts/core_bridge_mainnet/guardian_set_0.json \
+    --bind-address \
+    0.0.0.0 \
+    --clone-upgradeable-program \
+    3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5 \
+    --clone \
+    Es2E4JZuFwA5gcCs1ubmAegekraPnUxFNpxHfWfWFcqk \
+    --clone \
+    4tTfYz2SqRcZWqyBk1yHyEPzHjoHNbUErQbifBkLmzbT \
+    --clone-upgradeable-program \
+    CCTPmbSD7gX1bxKPAmg77w8oFzNFpaQiQUWD43TKaecd \
+    --clone \
+    AqT6GNqtiEpTjYhAeTwA1orjryPiFFTZ9REGqE93gpnx \
+    --clone \
+    7bu9ccL3uu9xNCLE4ZuUX43sg7HUfort8YyLxcq6G9cQ \
+    --clone-upgradeable-program \
+    wcihrWf1s91vfukW7LW8ZvR1rzpeZ9BrtZ8oyPkWK5d \
+    --clone \
+    7hs2RmXGHyLdNPDeB2yfWXEbKqJ2dyv6LGHERAArEUpy \
+    --clone-upgradeable-program \
+    CCTPiPYPc6AsJuwueEnWgSgucamXDZwBd53dQ11YiKX3 \
+    --rpc-port \
+    8899 \
+    --ticks-per-slot \
+    16 \
+    --url \
+    https://api.devnet.solana.com \
+    > /dev/null 2>&1 &
+
+echo $! > .validator_pid
+
+### Start up wait.
+sleep 10
+
+### Run the tests.
+anchor test --skip-build --skip-local-validator --skip-deploy
+
+EXIT_CODE=$?
+
+### Finally kill the validator.
+kill $(cat .validator_pid)
+rm .validator_pid
+
+exit $EXIT_CODE

--- a/solana/ts/scripts/pruneIdlTypes.ts
+++ b/solana/ts/scripts/pruneIdlTypes.ts
@@ -3,27 +3,31 @@ import * as fs from "fs";
 const BASENAME = "wormhole_circle_integration_solana";
 
 const ROOT = `${__dirname}/../..`;
+const IDL = `${ROOT}/target/idl/${BASENAME}.json`;
 const TYPES = `${ROOT}/target/types/${BASENAME}.ts`;
 
 const IGNORE_TYPES = [
-    '"name": "LocalToken"',
-    '"name": "TokenPair"',
-    '"name": "MessageTransmitterConfig"',
-    '"name": "WormholeCctp"',
+    // '"name": "LocalToken"',
+    // '"name": "TokenPair"',
+    // '"name": "MessageTransmitterConfig"',
+    // '"name": "WormholeCctp"',
+    //'"name": "ExternalAccount"',
 ];
 
 main();
 
 function main() {
-    if (!fs.existsSync(TYPES)) {
-        throw new Error("Types non-existent");
-    }
+    for (const fn of [IDL, TYPES]) {
+        if (!fs.existsSync(fn)) {
+            throw new Error(`${fn} non-existent`);
+        }
 
-    const types = fs.readFileSync(TYPES, "utf8").split("\n");
-    for (const matchStr of IGNORE_TYPES) {
-        while (spliceType(types, matchStr));
+        const types = fs.readFileSync(fn, "utf8").split("\n");
+        for (const matchStr of IGNORE_TYPES) {
+            while (spliceType(types, matchStr));
+        }
+        fs.writeFileSync(fn, types.join("\n"), "utf8");
     }
-    fs.writeFileSync(TYPES, types.join("\n"), "utf8");
 }
 
 function spliceType(lines: string[], matchStr: string) {

--- a/solana/ts/src/cctp/messageTransmitter/index.ts
+++ b/solana/ts/src/cctp/messageTransmitter/index.ts
@@ -1,5 +1,5 @@
-import { Program } from "@coral-xyz/anchor";
 import { Connection, PublicKey } from "@solana/web3.js";
+import { Program } from "anchor-0.29.0";
 import { CctpTokenBurnMessage } from "../messages";
 import { TokenMessengerMinterProgram } from "../tokenMessengerMinter";
 import { IDL, MessageTransmitter } from "../types/message_transmitter";

--- a/solana/ts/src/cctp/tokenMessengerMinter/index.ts
+++ b/solana/ts/src/cctp/tokenMessengerMinter/index.ts
@@ -1,5 +1,5 @@
-import { Program } from "@coral-xyz/anchor";
 import { Connection, PublicKey } from "@solana/web3.js";
+import { Program } from "anchor-0.29.0";
 import { MessageTransmitterProgram } from "../messageTransmitter";
 import { IDL, TokenMessengerMinter } from "../types/token_messenger_minter";
 import { RemoteTokenMessenger } from "./RemoteTokenMessenger";

--- a/solana/ts/src/index.ts
+++ b/solana/ts/src/index.ts
@@ -14,10 +14,8 @@ import {
     SystemProgram,
     TransactionInstruction,
 } from "@solana/web3.js";
-import {
-    IDL,
-    WormholeCircleIntegrationSolana,
-} from "../../target/types/wormhole_circle_integration_solana";
+import { WormholeCircleIntegrationSolana } from "../../target/types/wormhole_circle_integration_solana";
+import * as IDL from "../../target/idl/wormhole_circle_integration_solana.json";
 import {
     CctpTokenBurnMessage,
     MessageTransmitterProgram,
@@ -118,9 +116,12 @@ export class CircleIntegrationProgram {
 
     constructor(connection: Connection, programId?: ProgramId) {
         this._programId = programId ?? testnet();
-        this.program = new Program(IDL, new PublicKey(this._programId), {
-            connection,
-        });
+        this.program = new Program(
+            { ...(IDL as any), address: this._programId },
+            {
+                connection,
+            },
+        );
     }
 
     get ID(): PublicKey {
@@ -221,6 +222,7 @@ export class CircleIntegrationProgram {
                 upgradeAuthority: this.upgradeAuthorityAddress(),
                 programData: this.programDataAddress(),
                 bpfLoaderUpgradeableProgram: BPF_LOADER_UPGRADEABLE_ID,
+                systemProgram: SystemProgram.programId,
             })
             .instruction();
     }
@@ -255,6 +257,7 @@ export class CircleIntegrationProgram {
                 consumedVaa: this.consumedVaaAddress(vaaAcct.digest()),
                 registeredEmitter,
                 remoteTokenMessenger,
+                systemProgram: SystemProgram.programId,
             })
             .instruction();
     }
@@ -284,6 +287,7 @@ export class CircleIntegrationProgram {
                 rent: SYSVAR_RENT_PUBKEY,
                 clock: SYSVAR_CLOCK_PUBKEY,
                 bpfLoaderUpgradeableProgram: BPF_LOADER_UPGRADEABLE_ID,
+                systemProgram: SystemProgram.programId,
             })
             .instruction();
     }
@@ -395,6 +399,10 @@ export class CircleIntegrationProgram {
                 coreBridgeProgram,
                 tokenMessengerMinterProgram,
                 messageTransmitterProgram,
+                systemProgram: SystemProgram.programId,
+                tokenProgram: splToken.TOKEN_PROGRAM_ID,
+                rent: SYSVAR_RENT_PUBKEY,
+                clock: SYSVAR_CLOCK_PUBKEY,
             })
             .instruction();
     }
@@ -510,6 +518,8 @@ export class CircleIntegrationProgram {
                 tokenMessengerMinterEventAuthority,
                 tokenMessengerMinterProgram,
                 messageTransmitterProgram,
+                systemProgram: SystemProgram.programId,
+                tokenProgram: splToken.TOKEN_PROGRAM_ID,
             })
             .instruction();
     }

--- a/solana/tsconfig.json
+++ b/solana/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2023", "esnext", "dom"],
     "module": "commonjs",
     "target": "es2022",
+    "resolveJsonModule": true,
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
Anchor.toml's validator parameters do not apply anymore until the Anchor CLI can handle cloning upgradeable programs w/ >=1.18.